### PR TITLE
Add support for nuxt generate

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,3 +1,6 @@
+const resolve = require('path').resolve
+const fs = require('fs')
+
 const correspondances = {
   UserAgent: 'User-agent',
   CrawlDelay: 'Crawl-delay',
@@ -44,16 +47,26 @@ module.exports = function module(moduleOptions) {
 
   const renderedRobots = render(options);
 
-  this.addServerMiddleware({
-    path: 'robots.txt',
-    handler(req, res) {
-      res.setHeader('Content-Type', 'text/plain');
+  // If `nuxt generate`, write robots.txt to the static directory so it gets
+  // copied into the dist during generation.
+  if (process.env.npm_lifecycle_event == 'generate') {
+    const path = resolve(this.options.srcDir, this.options.dir.static, 'robots.txt')
+  	fs.writeFileSync(path, renderedRobots)
 
-      if (res.send) {
-        res.send(renderedRobots);
-      } else {
-        res.end(renderedRobots);
-      }
-    },
-  });
+  // If `nuxt dev` or `nuxt build`, render robots.txt via SSR
+  } else {
+    this.addServerMiddleware({
+      path: 'robots.txt',
+      handler(req, res) {
+        res.setHeader('Content-Type', 'text/plain');
+
+        if (res.send) {
+          res.send(renderedRobots);
+        } else {
+          res.end(renderedRobots);
+        }
+      },
+    });
+  }
+
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -47,9 +47,10 @@ module.exports = function module(moduleOptions) {
 
   const renderedRobots = render(options);
 
-  // If `nuxt generate`, write robots.txt to the static directory so it gets
-  // copied into the dist during generation.
-  if (process.env.npm_lifecycle_event == 'generate') {
+  // If `nuxt generate` or running in `spa` mode, write robots.txt to the static
+  // directory so it gets copied into the dist during generation.
+  console.log(this.options);
+  if (process.env.npm_lifecycle_event == 'generate' || this.options.mode == 'spa') {
     const path = resolve(this.options.srcDir, this.options.dir.static, 'robots.txt')
   	fs.writeFileSync(path, renderedRobots)
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -52,7 +52,7 @@ module.exports = function module(moduleOptions) {
   console.log(this.options);
   if (process.env.npm_lifecycle_event == 'generate' || this.options.mode == 'spa') {
     const path = resolve(this.options.srcDir, this.options.dir.static, 'robots.txt')
-  	fs.writeFileSync(path, renderedRobots)
+    fs.writeFileSync(path, renderedRobots)
 
   // If `nuxt dev` or `nuxt build`, render robots.txt via SSR
   } else {

--- a/lib/module.js
+++ b/lib/module.js
@@ -49,7 +49,6 @@ module.exports = function module(moduleOptions) {
 
   // If `nuxt generate` or running in `spa` mode, write robots.txt to the static
   // directory so it gets copied into the dist during generation.
-  console.log(this.options);
   if (process.env.npm_lifecycle_event == 'generate' || this.options.mode == 'spa') {
     const path = resolve(this.options.srcDir, this.options.dir.static, 'robots.txt')
     fs.writeFileSync(path, renderedRobots)


### PR DESCRIPTION
This adds support for `nuxt geneate` and `mode: spa`, where there isn't a web server running.  Instead of adding a middleware, it writes the robots.txt to the `static` directory,  whereupon it gets copied into `dist` during `build` or `generate`.